### PR TITLE
Change bee speed recommendations to Robotic over Blinding.

### DIFF
--- a/pages/06.gendustry/14.summary/docs.md
+++ b/pages/06.gendustry/14.summary/docs.md
@@ -28,7 +28,7 @@ You want to have a bee that has a short lifespan and has plenty of offspring. Th
 Genes to have on every breeding bee:
 
 * Fertility - 4 - If you can’t get 4, get it as high as possible.
-* Speed - Blinding
+* Speed - Robotic
 * Lifespan - Shortest
 * Rain - Tolerant
 * Nocturnal
@@ -39,7 +39,7 @@ A **Produce** focused bee would have the following traits:
 
 * Fertility - 1
 * Lifespan - Longest
-* Speed - Blinding
+* Speed - Robotic
 * Rain - Tolerant
 * Nocturnal
 

--- a/pages/07.genetics/11.recommended-bees/docs.md
+++ b/pages/07.genetics/11.recommended-bees/docs.md
@@ -33,7 +33,7 @@ As mentioned in the comments, output can be greatly improved (860%?) by using Al
 |--|--|--|
 | Species | Energy | Energy Bee |
 | Lifespan |  Longest | Relic Bee |
-| Production | Blinding | Amped Bee |
+| Production | Robotic | Robot Bee |
 | Pollination | Any | - |
 | Flower type | Any, Rocks recommended | Rocky Bee |
 | Fertility |Any, 1 recommended | Rocky Bee |
@@ -61,7 +61,7 @@ Original Post: [link](https://redd.it/8zsy90) (Credits to u/martmists)
 |--|--|--|
 | Species | Any | - |
 | Lifespan | Longest | Relic Bee |
-| Production | Blinding |Amped Bee |
+| Production | Robotic | Robot Bee |
 | Pollination | Any |- |
 | Flower type | Any, Rocks recommended | Rocky Bee |
 | Fertility | Any, 1 recommended | Rocky Bee |


### PR DESCRIPTION
As can be seen from the following source snippets:

```java
speedBlinding = new AlleleFloat(MagicBees.modid, "speed", "Blinding", 2.0f, false);
```

```java
ROBO_SPEED = createFloat("robotic", 2.5F, true, EnumBeeChromosome.SPEED);
```

The “Robotic” speed from CareerBees offers a 2.5x speed multiplier over MagicBee’s 2.0x multiplier from its “Blinding” speed. Since the guide assumes that you have both, I have update the relevant recommendations to use CB’s speed trait over MB’s.